### PR TITLE
[update] PROERTY -> PROPERTY

### DIFF
--- a/core/adbusb.c
+++ b/core/adbusb.c
@@ -172,7 +172,7 @@ const static char* _ustring[] =
 ALIGN(4)
 static struct usb_os_proerty winusb_proerty[] = 
 {
-    USB_OS_PROERTY_DESC(USB_OS_PROERTY_TYPE_REG_SZ,"DeviceInterfaceGUID",RT_WINUSB_GUID),
+    USB_OS_PROPERTY_DESC(USB_OS_PROPERTY_TYPE_REG_SZ,"DeviceInterfaceGUID",RT_WINUSB_GUID),
 };
 
 ALIGN(4)


### PR DESCRIPTION
rt-thread 那边的 USB_OS_PROPERTY_DESC 宏拼写错误修复了，所以这边也要同步更新才能编译通过。